### PR TITLE
Add Prefix to all parameters

### DIFF
--- a/internal/manager/password.go
+++ b/internal/manager/password.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	ssmClient ssmiface.SSMAPI
+	ssmClient    ssmiface.SSMAPI
+	seekepPrefix = "/sekeep"
 )
 
 type PasswordError struct {
@@ -35,7 +36,7 @@ func init() {
 func CreateOrUpdate(password model.Password) *PasswordError {
 	log.Infof("createOrUpdate started on password %s", password.Name)
 	_, err := ssmClient.PutParameter(&ssm.PutParameterInput{
-		Name:      aws.String(password.Name),
+		Name:      aws.String(seekepPrefix + password.Name),
 		Value:     aws.String(password.Value),
 		Type:      aws.String("SecureString"),
 		Overwrite: aws.Bool(password.Overwrite)})
@@ -57,7 +58,7 @@ func CreateOrUpdate(password model.Password) *PasswordError {
 func Delete(password model.Password) *PasswordError {
 	log.Infof("delete started on password %s", password.Name)
 	_, err := ssmClient.DeleteParameter(&ssm.DeleteParameterInput{
-		Name: aws.String(password.Name),
+		Name: aws.String(seekepPrefix + password.Name),
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "ParameterNotFound") {
@@ -73,7 +74,7 @@ func Delete(password model.Password) *PasswordError {
 func Read(password model.Password) (string, *PasswordError) {
 	log.Infof("read started on password %s", password.Name)
 	parameter, err := ssmClient.GetParameter(&ssm.GetParameterInput{
-		Name:           aws.String(password.Name),
+		Name:           aws.String(seekepPrefix + password.Name),
 		WithDecryption: aws.Bool(true),
 	})
 	if err != nil {

--- a/template.yaml
+++ b/template.yaml
@@ -41,6 +41,14 @@ Resources:
             - ssm:PutParameter
             - ssm:GetParameter
             - ssm:DeleteParameter
+            Resource: "arn:aws:ssm:*:*:parameter/sekeep/*"
+      - PolicyName: DescribeParameterStore
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - ssm:DescribeParameters
             Resource: "*"
 
   PasswordApi:

--- a/template.yaml
+++ b/template.yaml
@@ -74,10 +74,17 @@ Resources:
   AuthorizerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Role: !GetAtt LambdaExecutionRole.Arn
       CodeUri: target/
       Handler: auth
       Runtime: go1.x
+      Policies:
+      - Statement:
+        - Sid: GetToken
+          Effect: Allow
+          Action:
+          - ssm:GetParameter
+          Resource: 'arn:aws:ssm:*:*:parameter/sekeep-token'
+
 
   CreateFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
- Add `/sekeep/` as a prefix for all the parameters created through the API. 
- Update the Lambda role to only have access to prefixed parameters. 
- Update the role for the authorizer to have access tot he seekep-token. 