### PR TITLE
Fix: Password name

### DIFF
--- a/api/read/read.go
+++ b/api/read/read.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/WolkenOps/sekeep-api/internal/manager"
 	"github.com/WolkenOps/sekeep-api/internal/model"
@@ -13,7 +14,7 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 	password := model.Password{}
 
 	if value, ok := request.PathParameters["name"]; ok {
-		password.Name = value
+		password.Name, _ = url.QueryUnescape(value)
 		value, err := manager.Read(password)
 
 		if err != nil {


### PR DESCRIPTION
Name is used as id. We use `/` to struct password by domain so it need to be encoded so gateway can interpret it as part of the request and not as part of the URI. 